### PR TITLE
VTCCA-5448 changed getRecordsWithIncorrectTimestamp to check for all …

### DIFF
--- a/app/businessrates/authorisation/repositories/AccountsCache.scala
+++ b/app/businessrates/authorisation/repositories/AccountsCache.scala
@@ -81,7 +81,7 @@ class AccountsMongoCache @Inject()(db: MongoComponent)(implicit ec: ExecutionCon
   override def getRecordsWithIncorrectTimestamp: Future[Seq[String]] = {
     val longReads: Reads[String] = (__ \ "_id").read[String]
     collection
-      .find[BsonValue](`type`("createdAt", BsonType.STRING))
+      .find[BsonValue](not(`type`("createdAt", BsonType.DATE_TIME)))
       .projection(Projections.exclude("createdAt", "data"))
       .limit(10000)
       .toFuture()

--- a/test/businessrates/authorisation/services/AccountsCacheJobHandlerSpec.scala
+++ b/test/businessrates/authorisation/services/AccountsCacheJobHandlerSpec.scala
@@ -17,7 +17,7 @@
 package businessrates.authorisation.services
 
 import businessrates.authorisation.models.{Accounts, Organisation, Person, PersonDetails}
-import businessrates.authorisation.repositories.{AccountsMongoCache, Record}
+import businessrates.authorisation.repositories.AccountsMongoCache
 import businessrates.authorisation.services.jobHandler.AccountsCacheJobHandler
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{verify, when}
@@ -29,7 +29,6 @@ import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.Helpers.{await, defaultAwaitTimeout, running}
 
-import java.time.LocalDateTime
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 


### PR DESCRIPTION
…fields that are not dateTime Type