### PR TITLE
VTCCA-8092 Log modernised error responses

### DIFF
--- a/app/businessrates/authorisation/connectors/ModernisedBackendConnector.scala
+++ b/app/businessrates/authorisation/connectors/ModernisedBackendConnector.scala
@@ -17,18 +17,18 @@
 package businessrates.authorisation.connectors
 
 import businessrates.authorisation.models._
-import play.api.Logging
+import play.api.http.Status
 import play.api.libs.json.{Json, Reads}
 import uk.gov.hmrc.http.HttpReads.Implicits._
 import uk.gov.hmrc.http.client.HttpClientV2
-import uk.gov.hmrc.http.{HeaderCarrier, StringContextOps}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, StringContextOps, UpstreamErrorResponse}
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class ModernisedBackendConnector @Inject() (val http: HttpClientV2, servicesConfig: ServicesConfig)
-    extends BackendConnector with Logging {
+    extends BackendConnector with ModernisedRequestErrorLogging {
 
   val modernisedName = "modernised"
   lazy val backendUrl: String = servicesConfig.baseUrl(modernisedName)
@@ -65,11 +65,15 @@ class ModernisedBackendConnector @Inject() (val http: HttpClientV2, servicesConf
   )(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[Person]] = {
     implicit val apiFormat: Reads[Person] = Person.apiFormat
     val url = s"$individualAccountsUrl?governmentGatewayExternalId=$externalId"
-    http
-      .get(url"$url")
-      .setHeader(backendApiKeyHeader: _*)
-      .withProxy
-      .execute[Option[Person]]
+    logModernisedErrorResponse(
+      response = http
+        .get(url"$url")
+        .setHeader(backendApiKeyHeader: _*)
+        .withProxy
+        .execute[Option[Person]],
+      errorInfo = Seq("governmentGatewayExternalId" -> externalId),
+      url = url
+    )
   }
 
   private def getOrganisation(id: String, paramName: String)(implicit
@@ -78,11 +82,15 @@ class ModernisedBackendConnector @Inject() (val http: HttpClientV2, servicesConf
   ): Future[Option[Organisation]] = {
     implicit val apiFormat: Reads[Organisation] = Organisation.apiFormat
     val url = s"$groupAccountsUrl?$paramName=$id"
-    http
-      .get(url"$url")
-      .setHeader(backendApiKeyHeader: _*)
-      .withProxy
-      .execute[Option[Organisation]]
+    logModernisedErrorResponse(
+      response = http
+        .get(url"$url")
+        .setHeader(backendApiKeyHeader: _*)
+        .withProxy
+        .execute[Option[Organisation]],
+      errorInfo = Seq(paramName -> id),
+      url = url
+    )
   }
 
   override def updateCredentials(personId: String, groupId: String, externalId: String)(implicit
@@ -93,11 +101,25 @@ class ModernisedBackendConnector @Inject() (val http: HttpClientV2, servicesConf
 
     val headers = Seq("GG-Group-ID" -> groupId, "GG-External-ID" -> externalId) ++ backendApiKeyHeader
 
-    http
-      .patch(url"$url")
-      .withBody(Json.obj())
-      .setHeader(headers: _*)
-      .withProxy
-      .execute(throwOnFailure(readEitherOf(readUnit)), ec)
+    logModernisedErrorResponse(
+      response = http
+        .patch(url"$url")
+        .withBody(Json.obj())
+        .setHeader(headers: _*)
+        .withProxy
+        .execute[HttpResponse]
+        .flatMap { response =>
+          response.status match {
+            case status if Status.isSuccessful(status) => Future.unit
+            case status                                => Future.failed(UpstreamErrorResponse(response.body, status))
+          }
+        },
+      errorInfo = Seq(
+        "personId"   -> personId,
+        "groupId"    -> groupId,
+        "externalId" -> externalId
+      ),
+      url = url
+    )
   }
 }

--- a/app/businessrates/authorisation/connectors/ModernisedRequestErrorLogging.scala
+++ b/app/businessrates/authorisation/connectors/ModernisedRequestErrorLogging.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package businessrates.authorisation.connectors
+
+import play.api.Logging
+import uk.gov.hmrc.http.UpstreamErrorResponse
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait ModernisedRequestErrorLogging extends Logging {
+
+  protected def logModernisedErrorResponse[A](
+        response: Future[A],
+        errorInfo: => Seq[(String, String)],
+        url: => String
+  )(implicit ec: ExecutionContext): Future[A] =
+    response.recoverWith { case error: UpstreamErrorResponse =>
+      logError(error.statusCode, errorInfo, url)
+      Future.failed(error)
+    }
+
+  private def logError(statusCode: Int, errorInfo: Seq[(String, String)], url: String): Unit = {
+    val errorInfoString = (Seq(
+      "statusCode" -> statusCode.toString
+    ) ++ errorInfo :+ ("url" -> url))
+      .map { case (key, value) => s"$key=$value" }
+      .mkString(" ")
+
+    logger.warn(s"ModernisedError $errorInfoString")
+  }
+}

--- a/test/businessrates/authorisation/connectors/ModernisedRequestErrorLoggingSpec.scala
+++ b/test/businessrates/authorisation/connectors/ModernisedRequestErrorLoggingSpec.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package businessrates.authorisation.connectors
+
+import ch.qos.logback.classic.Level
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import play.api.Logger
+import uk.gov.hmrc.http.UpstreamErrorResponse
+import uk.gov.hmrc.play.bootstrap.tools.LogCapturing
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class ModernisedRequestErrorLoggingSpec extends AnyWordSpec with Matchers with ScalaFutures with LogCapturing {
+
+  private class TestConnector extends ModernisedRequestErrorLogging {
+    def execute[A](response: Future[A], errorInfo: => Seq[(String, String)], url: => String)(implicit
+          ec: ExecutionContext
+    ): Future[A] =
+      logModernisedErrorResponse(response, errorInfo, url)
+  }
+
+  private val connector = new TestConnector
+
+  implicit val ec: ExecutionContext = ExecutionContext.global
+
+  "logModernisedErrorResponse" should {
+    "log a WARN with relevant IDs when Modernised returns an error" in {
+      val upstreamError = UpstreamErrorResponse("Internal Server Error", 500)
+      val endpoint = "http://modernised/customer-management-api/credential/123"
+
+      withCaptureOfLoggingFrom(Logger(classOf[TestConnector])) { logs =>
+        whenReady(
+          connector
+            .execute(
+              response = Future.failed(upstreamError),
+              errorInfo = Seq(
+                "personId"   -> "123",
+                "groupId"    -> "group-id",
+                "externalId" -> "external-id"
+              ),
+              url = endpoint
+            )
+            .failed
+        ) { failed =>
+          failed shouldBe upstreamError
+        }
+
+        val warnLogs = logs.filter(_.getLevel == Level.WARN)
+        warnLogs should have size 1
+
+        val message = warnLogs.head.getMessage
+        message should include("ModernisedError")
+        message should include("statusCode=500")
+        message should include("personId=123")
+        message should include("groupId=group-id")
+        message should include("externalId=external-id")
+        message should include(s"url=$endpoint")
+      }
+    }
+  }
+}


### PR DESCRIPTION
When a request to Modernised fails, we now log a structured warning that includes the relevant request IDs (e.g. UARN, valuation ID) alongside the user's group and external IDs.